### PR TITLE
Fix the infinite loop problem

### DIFF
--- a/rocketmq/client.py
+++ b/rocketmq/client.py
@@ -457,7 +457,10 @@ class PullConsumer(object):
                 if pull_res.pullStatus == _CPullStatus.FOUND:
                     for i in range(int(pull_res.size)):
                         yield RecvMessage(pull_res.msgFoundList[i])
-                elif pull_res.pullStatus == _CPullStatus.NO_MATCHED_MSG:
+                elif pull_res.pullStatus in [_CPullStatus.NO_MATCHED_MSG, _CPullStatus.NO_NEW_MSG, _CPullStatus.OFFSET_ILLEGAL]:
+                    dll.ReleasePullResult(pull_res)  # NOTE: No need to check ffi return code here
+                    break
+                else:
                     dll.ReleasePullResult(pull_res)  # NOTE: No need to check ffi return code here
                     break
                 dll.ReleasePullResult(pull_res)  # NOTE: No need to check ffi return code here


### PR DESCRIPTION
fix bug: when there is no new message, it will be stuck on a specific message queue.

cpp code: https://github.com/apache/rocketmq-client-cpp/blob/9b239c94c11635df50bfa7557fde48b5f4b201e7/example/PullConsumer.cpp#L100

java example https://www.programcreek.com/java-api-examples/?code=medusar/rocketmq-commet/rocketmq-commet-master/rocketmq-tools/src/main/java/com/alibaba/rocketmq/tools/command/message/QueryMsgByOffsetSubCommand.java
```java
  @Override
    public void execute(CommandLine commandLine, Options options, RPCHook rpcHook) {
        DefaultMQAdminExt defaultMQAdminExt = new DefaultMQAdminExt(rpcHook);
        DefaultMQPullConsumer defaultMQPullConsumer = new DefaultMQPullConsumer(MixAll.TOOLS_CONSUMER_GROUP);

        defaultMQAdminExt.setInstanceName(Long.toString(System.currentTimeMillis()));
        defaultMQPullConsumer.setInstanceName(Long.toString(System.currentTimeMillis()));

        try {
            String topic = commandLine.getOptionValue('t').trim();
            String brokerName = commandLine.getOptionValue('b').trim();
            String queueId = commandLine.getOptionValue('i').trim();
            String offset = commandLine.getOptionValue('o').trim();

            MessageQueue mq = new MessageQueue();
            mq.setTopic(topic);
            mq.setBrokerName(brokerName);
            mq.setQueueId(Integer.parseInt(queueId));

            defaultMQPullConsumer.start();
            defaultMQAdminExt.start();

            PullResult pullResult = defaultMQPullConsumer.pull(mq, "*", Long.parseLong(offset), 1);
            if (pullResult != null) {
                switch (pullResult.getPullStatus()) {
                case FOUND:
                    QueryMsgByIdSubCommand.queryById(defaultMQAdminExt, pullResult.getMsgFoundList().get(0)
                        .getMsgId());
                    break;
                case NO_MATCHED_MSG:
                case NO_NEW_MSG:
                case OFFSET_ILLEGAL:
                default:
                    break;
                }
            }
        }
        catch (Exception e) {
            e.printStackTrace();
        }
        finally {
            defaultMQPullConsumer.shutdown();
            defaultMQAdminExt.shutdown();
        }
    }
}
```
