### PR TITLE
pull consumer add offset save

### DIFF
--- a/rocketmq/client.py
+++ b/rocketmq/client.py
@@ -483,5 +483,5 @@ class PullConsumer(object):
                     pass
                 else:
                     pass
-            dll.ReleasePullResult(pull_res)  # NOTE: No need to check ffi return code here
+                dll.ReleasePullResult(pull_res)  # NOTE: No need to check ffi return code here
         ffi_check(dll.ReleaseSubscriptionMessageQueue(message_queue))


### PR DESCRIPTION
The code implementation mimics the c++ version, depth-first traversing each message queue.
https://github.com/apache/rocketmq-client-cpp/blob/master/example/PullConsumer.cpp

if someone wants to save offset into such as redis, the two method `get_message_queue_offset` and `set_message_queue_offset` could be overrided.
